### PR TITLE
add clickable modifier & BeautifulButton refactor

### DIFF
--- a/Sources/CyanUI/AnimatedClickable.swift
+++ b/Sources/CyanUI/AnimatedClickable.swift
@@ -1,0 +1,143 @@
+//
+//  Created by Cyandev on 2022/1/22.
+//  Copyright (c) 2021 Cyandev. All rights reserved.
+//
+
+import SwiftUI
+
+public struct AnimatedClickableConfiguration {
+    
+    public var activeAnimation: Animation
+    public var identityAnimation: Animation
+    
+    public private(set) var activeModifier: AnyViewModifier
+    public private(set) var identityModifier: AnyViewModifier
+    
+    /// A default configuration with spring animation and highlight effect.
+    public static let highlight = Self.empty().activeOpacity(0.3)
+    
+    /// An empty configuration with the given animations, which has no active effects.
+    public static func empty(
+        activeAnimation: Animation = .spring(response: 0.1),
+        identityAnimation: Animation = .spring(response: 0.6)
+    ) -> Self {
+        return .init(
+            activeAnimation: activeAnimation,
+            identityAnimation: identityAnimation,
+            activeModifier: .init(),
+            identityModifier: .init()
+        )
+    }
+    
+    public func combined<E>(with modifierBuilder: (_ active: Bool) -> E) -> Self where E: ViewModifier {
+        var copy = self
+        copy.activeModifier = copy.activeModifier.typeErasedConcat(modifierBuilder(true))
+        copy.identityModifier = copy.identityModifier.typeErasedConcat(modifierBuilder(false))
+        return copy
+    }
+    
+    public func activeScale(_ scale: CGFloat) -> Self {
+        combined { active in
+            AnyViewModifier { $0.scaleEffect(active ? scale : 1) }
+        }
+    }
+    
+    public func activeOpacity(_ opacity: CGFloat) -> Self {
+        combined { active in
+            AnyViewModifier {
+                $0.compositingGroup()
+                    .opacity(active ? opacity : 1)
+            }
+        }
+    }
+    
+}
+
+public struct AnimatedClickableModifier: ViewModifier {
+    
+    public let configuration: AnimatedClickableConfiguration
+    public let action: () -> ()
+    
+    public init(configuration: AnimatedClickableConfiguration, action: @escaping () -> ()) {
+        self.configuration = configuration
+        self.action = action
+    }
+    
+    public func body(content: Content) -> some View {
+        _AnimatedClickableView(content, configuration: configuration, action: action)
+    }
+    
+}
+
+public extension View {
+    
+    func animatedClickable(
+        configuration: AnimatedClickableConfiguration = .highlight,
+        action: @escaping () -> ()
+    ) -> some View {
+        modifier(AnimatedClickableModifier(configuration: configuration, action: action))
+    }
+    
+}
+
+private struct _AnimatedClickableView<V>: View where V: View {
+    
+    private let content: V
+    private let configuration: AnimatedClickableConfiguration
+    private let action: () -> ()
+
+    @State private var viewSize: CGSize = .zero
+    @State private var isPressed: Bool = false
+    @State private var isPointInside: Bool = false
+    
+    init(_ content: V, configuration: AnimatedClickableConfiguration, action: @escaping () -> ()) {
+        self.content = content
+        self.configuration = configuration
+        self.action = action
+    }
+    
+    var body: some View {
+        content
+            .overlay(sizeReader())
+            .modifier(isPointInside
+                ? configuration.activeModifier
+                : configuration.identityModifier)
+            .highPriorityGesture(dragGesture())
+    }
+    
+    private func dragGesture() -> some Gesture {
+        DragGesture(minimumDistance: 0)
+            .onChanged { value in
+                withAnimation(isPressed
+                              ? configuration.identityAnimation
+                              : configuration.activeAnimation) {
+                    let activeZone = CGRect(origin: .zero, size: viewSize)
+                        .insetBy(dx: -24, dy: -24)
+                    isPointInside = activeZone.contains(value.location)
+                }
+                isPressed = true
+            }
+            .onEnded { _ in
+                if isPointInside {
+                    action()
+                }
+                withAnimation(configuration.identityAnimation) {
+                    isPressed = false
+                    isPointInside = false
+                }
+            }
+    }
+    
+    private func sizeReader() -> some View {
+        GeometryReader { proxy in
+            Color.clear
+                .onChange(of: proxy.size) { newValue in
+                    viewSize = newValue
+                }
+                .onAppear {
+                    viewSize = proxy.size
+                }
+        }
+    }
+    
+}

--- a/Sources/CyanUI/AnyViewModifier.swift
+++ b/Sources/CyanUI/AnyViewModifier.swift
@@ -1,0 +1,37 @@
+//
+//  Created by Cyandev on 2022/1/22.
+//  Copyright (c) 2021 Cyandev. All rights reserved.
+//
+
+import SwiftUI
+import CyanUtils
+
+public struct AnyViewModifier: ViewModifier {
+    
+    private let bodyBuilder: (Content) -> AnyView
+    
+    public init<V>(@ViewBuilder _ viewModifier: @escaping (Content) -> V) where V: View {
+        bodyBuilder = { content in
+            AnyView(content |> viewModifier)
+        }
+    }
+    
+    public init<V>(_ viewModifier: V) where V: ViewModifier {
+        bodyBuilder = { content in
+            AnyView(content.modifier(viewModifier))
+        }
+    }
+    
+    public init() {
+        bodyBuilder = { AnyView($0) }
+    }
+    
+    public func body(content: Content) -> some View {
+        content |> bodyBuilder
+    }
+    
+    public func typeErasedConcat<T>(_ modifier: T) -> AnyViewModifier where T: ViewModifier {
+        return .init(concat(modifier))
+    }
+    
+}

--- a/Sources/CyanUI/BeautifulButton.swift
+++ b/Sources/CyanUI/BeautifulButton.swift
@@ -75,35 +75,15 @@ public struct BeautifulButton: View {
                     }
                 }
             )
-            .overlay(
-                GeometryReader { proxy in
-                    Color(white: 0, opacity: (pressed && style == .fill) ? 0.3 : 0)
-                        .onChange(of: proxy.size) { newValue in
-                            buttonSize = proxy.size
-                        }
-                        .onAppear {
-                            buttonSize = proxy.size
-                        }
+            .animatedClickable(configuration: .empty(
+                activeAnimation: .spring(response: 0.2),
+                identityAnimation: .spring(response: 0.35)
+            ).combined(with: { active in
+                AnyViewModifier {
+                    $0.overlay(Color(white: 0, opacity: active && style == .fill ? 0.3 : 0))
+                        .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
                 }
-            )
-            .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
-            .scaleEffect(scaleRatio, anchor: .center)
-            .highPriorityGesture(
-                DragGesture(minimumDistance: 0)
-                    .onChanged({ value in
-                        withAnimation(.spring(response: 0.2)) {
-                            pressed = CGRect(origin: .zero, size: buttonSize).contains(value.location)
-                        }
-                    })
-                    .onEnded({ value in
-                        if pressed {
-                            action()
-                        }
-                        withAnimation(.spring(response: 0.35)) {
-                            pressed = false
-                        }
-                    })
-            )
+            }).activeScale(0.9), action: action)
     }
     
     public func buttonStyle(_ style: Style) -> BeautifulButton {


### PR DESCRIPTION
We love `BeautifulButton`, but sometimes we need more customization abilities for buttons. We found that there are a lot of duplicated works to do to make a new button, especially when implementing the press & drag interaction. Therefore we made a brand-new modifier to add button-like interaction to arbitrary views.

Of course, `BeautifulButton` also needs refactor, with the new modifier.