### PR TITLE
Add `HostingViewReader`

### DIFF
--- a/Sources/CyanUI/HostingViewReader.swift
+++ b/Sources/CyanUI/HostingViewReader.swift
@@ -1,0 +1,69 @@
+//
+//  Created by ktiays on 2022/1/22.
+//  Copyright (c) 2022 ktiays. All rights reserved.
+// 
+
+import SwiftUI
+#if os(macOS)
+import AppKit
+typealias ViewRepresentable = NSViewRepresentable
+#else
+import UIKit
+typealias ViewRepresentable = UIViewRepresentable
+#endif
+
+struct HostingViewReader<Content>: ViewRepresentable where Content: View {
+    
+    #if os(macOS)
+    
+    typealias PlatformView = NSView
+    typealias PlatformHostingView = NSHostingView
+    
+    func makeNSView(context: Context) -> _HostingView {
+        .init(content: self.contentBuilder)
+    }
+    
+    func updateNSView(_ nsView: _HostingView, context: Context) { }
+    
+    #else
+    
+    typealias PlatformView = UIView
+    typealias PlatformHostingView = _UIHostingView
+    
+    func makeUIView(context: Context) -> _HostingView {
+        .init(content: self.contentBuilder)
+    }
+    
+    func updateUIView(_ uiView: _HostingView, context: Context) { }
+    
+    #endif
+    
+    private let contentBuilder: (PlatformView) -> Content
+
+    
+    init(@ViewBuilder content: @escaping (PlatformView) -> Content) {
+        self.contentBuilder = content
+    }
+    
+    final class _HostingView: PlatformView {
+        
+        private var contentView: Content!
+        
+        fileprivate init(@ViewBuilder content: (PlatformView) -> Content) {
+            super.init(frame: .zero)
+            self.contentView = content(self)
+
+            let hostingContentView = PlatformHostingView(rootView: self.contentView)
+            addSubview(hostingContentView)
+            hostingContentView.snp.makeConstraints { make in
+                make.edges.equalToSuperview()
+            }
+        }
+        
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+        
+    }
+    
+}

--- a/Sources/CyanUI/HostingViewReader.swift
+++ b/Sources/CyanUI/HostingViewReader.swift
@@ -56,7 +56,7 @@ public struct HostingViewReader<Content>: ViewRepresentable where Content: View 
             hostingView = .init(rootView: nil)
             #else
             hostingViewController = .init(rootView: nil)
-            let hostingView = hostingViewController.view!
+            let hostingView: UIView = hostingViewController.view
             #endif
             hostingView.translatesAutoresizingMaskIntoConstraints = false
             


### PR DESCRIPTION
Accessing platform views in SwiftUI is necessary sometimes, but the process can be verbose. Here we add a new view to make this easier. See the file changes to learn more.